### PR TITLE
Corrected setColConfig example

### DIFF
--- a/01.-about/gridconnector-methods.md
+++ b/01.-about/gridconnector-methods.md
@@ -11,10 +11,10 @@ let columnConfigArray = this.gridConnector.getColConfig();
 ## setColConfig\(colconfig: ColConfig\[\]\): void
 
 ```text
-this.gridConnector.getColConfig(columnConfigArray);
+this.gridConnector.setColConfig(columnConfigArray);
 
 //resets to default (html, or when grid loaded of no html)
-this.gridConnector.getColConfig(null)
+this.gridConnector.setColConfig(null)
 ```
 
 Interface


### PR DESCRIPTION
Renamed getColConfig to setColConfig for the example.